### PR TITLE
Make sure we use the system nc

### DIFF
--- a/anybar.plugin.zsh
+++ b/anybar.plugin.zsh
@@ -1,3 +1,3 @@
 #!/usr/bin/env zsh
 
-function anybar { echo -n $1 | nc -4u -w0 localhost ${2:-1738}; }
+function anybar { echo -n $1 | /usr/bin/nc -4u -w0 localhost ${2:-1738}; }


### PR DESCRIPTION
I have a version of `nc` installed in `/usr/local/bin` from Homebrew whose arguments are incompatible with the system supplied version of `nc`.

This little fix ensures that we always use the system supplied `nc`.